### PR TITLE
add code to show prob and idx of each data

### DIFF
--- a/Classification/Classification.py
+++ b/Classification/Classification.py
@@ -3,6 +3,8 @@ import torch
 import torchvision
 import torchvision.transforms as transforms
 from torch_sample import CNN
+import torch.nn as nn
+
 
 test_img_dir = r""
 
@@ -11,6 +13,8 @@ def main():
     # モデル読み込み
     model = CNN()
     model.load_state_dict(torch.load("model.pth"))
+    
+    softmax = nn.Softmax(dim=1) 
 
     # transform定義
     transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
@@ -32,6 +36,12 @@ def main():
             test_data, teacher_labels = data
             # 検証データをモデルに渡し予測
             results = model(test_data)
+            
+            pred = softmax(results)
+            prob, idx = torch.max(pred, 1) #probability and index of each data
+            print(prob)
+            print(idx)
+            """============================================================
             # 予測結果を取得
             _, predicted = torch.max(results, 1) 
             c = (predicted == teacher_labels).squeeze()
@@ -39,6 +49,7 @@ def main():
                 label = teacher_labels[i]
                 class_corrent[label] += c[i].item()
                 class_total[label] += 1
+            """
     # 結果表示
     for i in range(10):
         print(' %5s クラスの正解率: %2d %%' % (class_names[i], 100 * class_corrent[i] / class_total[i]))


### PR DESCRIPTION
train_model.pyを見るとモデルは最後84 -> 10次元の線形層があり、(data_num, 10)のベクトルが出力される（ソフトマックス関数がないのでこの時点では確率に変換されていない）のでsoftmax関数追加、以下元コードと同様